### PR TITLE
Fix parameter assignment for Checksum

### DIFF
--- a/AdoptOpenJDK/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_windows_hotspot_12.0.2_10.zip'
-$checksum64  = 'e18f523cb71d7928cdb5fe8e567ab5f7336b3674f920e9e0d4052ba9639964a6'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_windows_hotspot_12.0.2_10.zip'
+    Checksum64       = 'e18f523cb71d7928cdb5fe8e567ab5f7336b3674f920e9e0d4052ba9639964a6'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.2+10 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-12.0.2+10\bin' -PathType 'Machine'

--- a/AdoptOpenJDK11/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK11/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_windows_hotspot_11.0.4_11.zip'
-$checksum64  = '6e49694fa9462433f08c131fa11d8d1c78f89afbc5a0249886c262ae1c8dd8f4'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_windows_hotspot_11.0.4_11.zip'
+    Checksum64       = '6e49694fa9462433f08c131fa11d8d1c78f89afbc5a0249886c262ae1c8dd8f4'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-11.0.4+11 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-11.0.4+11\bin' -PathType 'Machine'

--- a/AdoptOpenJDK11JRE/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK11JRE/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_windows_hotspot_11.0.4_11.zip'
-$checksum64  = 'be88c679fd24194bee71237f92f7a2a71c88f71a853a56a7c05742b0e158c1be'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_windows_hotspot_11.0.4_11.zip'
+    Checksum64       = 'be88c679fd24194bee71237f92f7a2a71c88f71a853a56a7c05742b0e158c1be'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-11.0.4+11-jre 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-11.0.4+11-jre\bin' -PathType 'Machine'

--- a/AdoptOpenJDK12/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK12/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_windows_hotspot_12.0.2_10.zip'
-$checksum64  = 'e18f523cb71d7928cdb5fe8e567ab5f7336b3674f920e9e0d4052ba9639964a6'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_windows_hotspot_12.0.2_10.zip'
+    Checksum64       = 'e18f523cb71d7928cdb5fe8e567ab5f7336b3674f920e9e0d4052ba9639964a6'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.2+10 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-12.0.2+10\bin' -PathType 'Machine'

--- a/AdoptOpenJDK12JRE/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK12JRE/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jre_x64_windows_hotspot_12.0.2_10.zip'
-$checksum64  = 'c03fdbced77d74557d2ede7a120b09e2573dde7527a4c019458b6f20920aa632'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jre_x64_windows_hotspot_12.0.2_10.zip'
+    Checksum64       = 'c03fdbced77d74557d2ede7a120b09e2573dde7527a4c019458b6f20920aa632'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.2+10-jre 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-12.0.2+10-jre\bin' -PathType 'Machine'

--- a/AdoptOpenJDK8/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK8/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b04/OpenJDK8U-jdk_x64_windows_hotspot_8u212b04.zip'
-$checksum64  = 'bc16200794603d41cf0402cc8af7e24d4ba32a48608505a7cead9c4997b526fa'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b04/OpenJDK8U-jdk_x64_windows_hotspot_8u212b04.zip'
+    Checksum64       = 'bc16200794603d41cf0402cc8af7e24d4ba32a48608505a7cead9c4997b526fa'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk8u212-b04 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk8u212-b04\bin' -PathType 'Machine'

--- a/AdoptOpenJDK8JRE/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDK8JRE/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jre_x64_windows_hotspot_8u212b03.zip'
-$checksum64  = 'c09bab89cd82483c371597c5c364094a145c1fbba43a1d3d7c3e350b89dedc89'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jre_x64_windows_hotspot_8u212b03.zip'
+    Checksum64       = 'c09bab89cd82483c371597c5c364094a145c1fbba43a1d3d7c3e350b89dedc89'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk8u212-b03-jre 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk8u212-b03-jre\bin' -PathType 'Machine'

--- a/AdoptOpenJDKJRE/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDKJRE/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jre_x64_windows_hotspot_12.0.2_10.zip'
-$checksum64  = 'c03fdbced77d74557d2ede7a120b09e2573dde7527a4c019458b6f20920aa632'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jre_x64_windows_hotspot_12.0.2_10.zip'
+    Checksum64       = 'c03fdbced77d74557d2ede7a120b09e2573dde7527a4c019458b6f20920aa632'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.2+10-jre 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-12.0.2+10-jre\bin' -PathType 'Machine'

--- a/AdoptOpenJDKOpenJ9JDK/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDKOpenJ9JDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jdk_x64_windows_openj9_12.0.1_12_openj9-0.14.1.zip'
-$checksum64  = 'c788c03d58ecb875b1a719591b455cfe89a204293d1fabb7fa88767d545d47cd'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jdk_x64_windows_openj9_12.0.1_12_openj9-0.14.1.zip'
+    Checksum64       = 'c788c03d58ecb875b1a719591b455cfe89a204293d1fabb7fa88767d545d47cd'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.1+12 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-12.0.1+12\bin' -PathType 'Machine'

--- a/AdoptOpenJDKOpenJ9JRE/tools/chocolateyinstall.ps1
+++ b/AdoptOpenJDKOpenJ9JRE/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\AdoptOpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jre_x64_windows_openj9_12.0.1_12_openj9-0.14.1.zip'
-$checksum64  = '55b827dbcba370b9b527b6db1bfea485d555e1626c76389c3d635fca1d4257be'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\AdoptOpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jre_x64_windows_openj9_12.0.1_12_openj9-0.14.1.zip'
+    Checksum64       = '55b827dbcba370b9b527b6db1bfea485d555e1626c76389c3d635fca1d4257be'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.1+12-jre 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\AdoptOpenJDK\jdk-12.0.1+12-jre\bin' -PathType 'Machine'

--- a/Corretto11JDK/tools/chocolateyinstall.ps1
+++ b/Corretto11JDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\Corretto'
-$url64       = 'https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip'
-$checksum64  = '707c839c3f56645454b8c8d31f255161'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\Corretto'
+    Url64            = 'https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip'
+    Checksum64       = '707c839c3f56645454b8c8d31f255161'
+    ChecksumType64   = 'md5'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk11.0.4_10 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\Corretto\jdk11.0.4_10\bin' -PathType 'Machine'

--- a/Corretto8JDK/tools/chocolateyinstall.ps1
+++ b/Corretto8JDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\Corretto'
-$url64       = 'https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/amazon-corretto-8.222.10.3-windows-x64-jdk.zip'
-$checksum64  = '9879a7f69c0bd7d8c1bbb916df7b5f82'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\Corretto'
+    Url64            = 'https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/amazon-corretto-8.222.10.3-windows-x64-jdk.zip'
+    Checksum64       = '9879a7f69c0bd7d8c1bbb916df7b5f82'
+    ChecksumType64   = 'md5'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk1.8.0_222 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\Corretto\jdk1.8.0_222\bin' -PathType 'Machine'

--- a/Corretto8JRE/tools/chocolateyinstall.ps1
+++ b/Corretto8JRE/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\Corretto'
-$url64       = 'https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/amazon-corretto-8.222.10.3-windows-x64-jre.zip'
-$checksum64  = '6903e6c0c13204d35ed70430ed568777'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\Corretto'
+    Url64            = 'https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/amazon-corretto-8.222.10.3-windows-x64-jre.zip'
+    Checksum64       = '6903e6c0c13204d35ed70430ed568777'
+    ChecksumType64   = 'md5'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jre8 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\Corretto\jre8\bin' -PathType 'Machine'

--- a/CorrettoJDK/tools/chocolateyinstall.ps1
+++ b/CorrettoJDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\Corretto'
-$url64       = 'https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip'
-$checksum64  = '707c839c3f56645454b8c8d31f255161'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\Corretto'
+    Url64            = 'https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip'
+    Checksum64       = '707c839c3f56645454b8c8d31f255161'
+    ChecksumType64   = 'md5'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk11.0.4_10 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\Corretto\jdk11.0.4_10\bin' -PathType 'Machine'

--- a/GraalVM/tools/chocolateyinstall.ps1
+++ b/GraalVM/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\GraalVM'
-$url64       = 'https://github.com/oracle/graal/releases/download/vm-19.1.0/graalvm-ce-windows-amd64-19.1.0.zip'
-$checksum64  = '54D71BC3D43F7F05D1736547FD24ADD42A6199C5790413A948974E558739B0AA'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\GraalVM'
+    Url64            = 'https://github.com/oracle/graal/releases/download/vm-19.1.0/graalvm-ce-windows-amd64-19.1.0.zip'
+    Checksum64       = '54D71BC3D43F7F05D1736547FD24ADD42A6199C5790413A948974E558739B0AA'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\graalvm-ce-19.1.0 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\GraalVM\graalvm-ce-19.1.0\bin' -PathType 'Machine'

--- a/Liberica11JDK/tools/chocolateyinstall.ps1
+++ b/Liberica11JDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\Liberica'
-$url64       = 'https://github.com/bell-sw/Liberica/releases/download/11.0.2/bellsoft-jdk11.0.2-windows-amd64.zip'
-$checksum64  = '4F2109361256B33A15CD8A6E2C21BC473875C05A'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\Liberica'
+    Url64            = 'https://github.com/bell-sw/Liberica/releases/download/11.0.2/bellsoft-jdk11.0.2-windows-amd64.zip'
+    Checksum64       = '4F2109361256B33A15CD8A6E2C21BC473875C05A'
+    ChecksumType64   = 'sha1'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-11.0.2 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\Liberica\jdk-11.0.2\bin' -PathType 'Machine'

--- a/LibericaJDK/tools/chocolateyinstall.ps1
+++ b/LibericaJDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\Liberica'
-$url64       = 'https://download.bell-sw.com/java/12.0.1/bellsoft-jdk12.0.1-windows-amd64.zip'
-$checksum64  = '6E06B7416152EF3E1DC3BF170485ABC22F3D1DF6'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\Liberica'
+    Url64            = 'https://download.bell-sw.com/java/12.0.1/bellsoft-jdk12.0.1-windows-amd64.zip'
+    Checksum64       = '6E06B7416152EF3E1DC3BF170485ABC22F3D1DF6'
+    ChecksumType64   = 'sha1'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.1 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\Liberica\jdk-12.0.1\bin' -PathType 'Machine'

--- a/OpenJDK/tools/chocolateyinstall.ps1
+++ b/OpenJDK/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\OpenJDK'
-$url64       = 'https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_windows-x64_bin.zip'
-$checksum64  = 'a30bed3d6d62f6ae1052aaf3c6956aaee8e3deb2f50f155575112f3f29411fba'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\OpenJDK'
+    Url64            = 'https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_windows-x64_bin.zip'
+    Checksum64       = 'a30bed3d6d62f6ae1052aaf3c6956aaee8e3deb2f50f155575112f3f29411fba'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.2 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\OpenJDK\jdk-12.0.2\bin' -PathType 'Machine'

--- a/OpenJDK11/tools/chocolateyinstall.ps1
+++ b/OpenJDK11/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\OpenJDK'
-$url64       = 'https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip'
-$checksum64  = 'cf39490fe042dba1b61d6e9a395095279a69e70086c8c8d5466d9926d80976d8'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\OpenJDK'
+    Url64            = 'https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip'
+    Checksum64       = 'cf39490fe042dba1b61d6e9a395095279a69e70086c8c8d5466d9926d80976d8'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-11.0.2 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\OpenJDK\jdk-11.0.2\bin' -PathType 'Machine'

--- a/OpenJDK11RedHatBuild/tools/chocolateyinstall.ps1
+++ b/OpenJDK11RedHatBuild/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\OpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_windows_11.0.3_7.zip'
-$checksum64  = '595BA894D2CF7857FD59D8532FFD6D25E80211F7012EBCB4E5A9258770412484'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\OpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_windows_11.0.3_7.zip'
+    Checksum64       = '595BA894D2CF7857FD59D8532FFD6D25E80211F7012EBCB4E5A9258770412484'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\openjdk-11u-11.0.3+7 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\OpenJDK\openjdk-11u-11.0.3+7\bin' -PathType 'Machine'

--- a/OpenJDK12/tools/chocolateyinstall.ps1
+++ b/OpenJDK12/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\OpenJDK'
-$url64       = 'https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_windows-x64_bin.zip'
-$checksum64  = 'a30bed3d6d62f6ae1052aaf3c6956aaee8e3deb2f50f155575112f3f29411fba'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\OpenJDK'
+    Url64            = 'https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_windows-x64_bin.zip'
+    Checksum64       = 'a30bed3d6d62f6ae1052aaf3c6956aaee8e3deb2f50f155575112f3f29411fba'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\jdk-12.0.2 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\OpenJDK\jdk-12.0.2\bin' -PathType 'Machine'

--- a/OpenJDK8RedHatBuild/tools/chocolateyinstall.ps1
+++ b/OpenJDK8RedHatBuild/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\OpenJDK'
-$url64       = 'https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8u-x64_windows_8u212b03.zip'
-$checksum64  = '9942E99168D1D582820A2DB56922A702F3909379E1E302DE983D7DF9111AAD8F'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\OpenJDK'
+    Url64            = 'https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8u-x64_windows_8u212b03.zip'
+    Checksum64       = '9942E99168D1D582820A2DB56922A702F3909379E1E302DE983D7DF9111AAD8F'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\openjdk-8u212-b03 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\OpenJDK\openjdk-8u212-b03\bin' -PathType 'Machine'

--- a/SapMachine/tools/chocolateyinstall.ps1
+++ b/SapMachine/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\SapMachine'
-$url64       = 'https://github.com/SAP/SapMachine/releases/download/sapmachine-12.0.1/sapmachine-jdk-12.0.1_windows-x64_bin.zip'
-$checksum64  = '94be7be2a9c201f8ea4718be168b461b6c01043b48801ff67cf32c801a32b5e5'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\SapMachine'
+    Url64            = 'https://github.com/SAP/SapMachine/releases/download/sapmachine-12.0.1/sapmachine-jdk-12.0.1_windows-x64_bin.zip'
+    Checksum64       = '94be7be2a9c201f8ea4718be168b461b6c01043b48801ff67cf32c801a32b5e5'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\sapmachine-jdk-12.0.1 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\SapMachine\sapmachine-jdk-12.0.1\bin' -PathType 'Machine'

--- a/SapMachine11/tools/chocolateyinstall.ps1
+++ b/SapMachine11/tools/chocolateyinstall.ps1
@@ -1,9 +1,12 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\SapMachine'
-$url64       = 'https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.3/sapmachine-jdk-11.0.3_windows-x64_bin.zip'
-$checksum64  = 'dd1299a577fd8f61003eb20baf999a3135ba968f0620f37a477f96afc2c1fc3b'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\SapMachine'
+    Url64            = 'https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.3/sapmachine-jdk-11.0.3_windows-x64_bin.zip'
+    Checksum64       = 'dd1299a577fd8f61003eb20baf999a3135ba968f0620f37a477f96afc2c1fc3b'
+    ChecksumType64   = 'sha256'
+}
 
-Install-ChocolateyZipPackage $packageName $url64 $targetDir
+Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyEnvironmentVariable 'JAVA_HOME' $targetDir\sapmachine-jdk-11.0.3 'Machine'
 # The full path instead of the %JAVA_HOME% is needed so it can be removed with the Chocolatey Uninstall
 Install-ChocolateyPath 'C:\Program Files\SapMachine\sapmachine-jdk-11.0.3\bin' -PathType 'Machine'

--- a/WildFly/tools/chocolateyinstall.ps1
+++ b/WildFly/tools/chocolateyinstall.ps1
@@ -1,6 +1,9 @@
-﻿$packageName = $env:ChocolateyPackageName
-$targetDir   = 'C:\Program Files\WildFly'
-$url         = 'https://download.jboss.org/wildfly/16.0.0.Final/wildfly-16.0.0.Final.zip'
-$checksum    = 'b55ed374ab4f8534c2343ac9a283c71fa6d22dfe'
+﻿$packageArgs = @{
+    PackageName      = $env:ChocolateyPackageName
+    UnzipLocation    = $targetDir = 'C:\Program Files\WildFly'
+    Url              = 'https://download.jboss.org/wildfly/16.0.0.Final/wildfly-16.0.0.Final.zip'
+    Checksum         = 'b55ed374ab4f8534c2343ac9a283c71fa6d22dfe'
+    ChecksumType     = 'sha1'
+}
 
-Install-ChocolateyZipPackage $packageName $url $targetDir
+Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
In the current code, the hash value is not validated.
To resolve this issue, make the following changes:

* Assigned Checksum64 parameter.
* For binaries only for x64, assigned to Url64 parameter.
* Changed parameter assignment to splatting (like #7 )

You can see that the hash value has been validated successfully since "Hashes match." text is output in the CI Job log.