### PR TITLE
Update microsoft-openjdk, microsoft-openjdk11 & microsoft-openjdk17

### DIFF
--- a/Microsoft-OpenJDK/microsoft-openjdk.nuspec
+++ b/Microsoft-OpenJDK/microsoft-openjdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-openjdk</id>
-    <version>17.0.6</version>
+    <version>17.0.8</version>
     <packageSourceUrl>https://github.com/johanjanssen/ChocolateyPackages/tree/master/Microsoft-OpenJDK</packageSourceUrl>
     <title>Microsoft build of OpenJDK</title>
     <authors>Microsoft</authors>

--- a/Microsoft-OpenJDK/tools/chocolateyinstall.ps1
+++ b/Microsoft-OpenJDK/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://aka.ms/download-jdk/microsoft-jdk-17.0.6-windows-x64.msi'
-  Checksum64 = 'ad3c2ea8b991bcb99eedff9d09962ae8d2fe8215955b5ce3f268c42cd492bcc8'
+  Url64bit = 'https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.msi'
+  Checksum64 = 'f029e88cdadce4e32bf8e45c2ae31d6015996f10bd836eb255bae86d8246d332'
   ChecksumType64 = 'sha256'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/Microsoft-OpenJDK11/microsoft-openjdk11.nuspec
+++ b/Microsoft-OpenJDK11/microsoft-openjdk11.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-openjdk11</id>
-    <version>11.0.18</version>
+    <version>11.0.20</version>
     <packageSourceUrl>https://github.com/johanjanssen/ChocolateyPackages/tree/master/Microsoft-OpenJDK11</packageSourceUrl>
     <title>Microsoft build of OpenJDK 11</title>
     <authors>Microsoft</authors>

--- a/Microsoft-OpenJDK11/tools/chocolateyinstall.ps1
+++ b/Microsoft-OpenJDK11/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://aka.ms/download-jdk/microsoft-jdk-11.0.18-windows-x64.msi'
-  Checksum64 = 'fa0ef7750af784f947f29c41659532d174c11210f05e3e36d1c422993ba8709e'
+  Url64bit = 'https://aka.ms/download-jdk/microsoft-jdk-11.0.20-windows-x64.msi'
+  Checksum64 = 'f0a0e4d5255e7844faa0ae508e7410c0d6bc1d9c0b596f62ff1224e81af341f2'
   ChecksumType64 = 'sha256'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/Microsoft-OpenJDK17/microsoft-openjdk17.nuspec
+++ b/Microsoft-OpenJDK17/microsoft-openjdk17.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-openjdk17</id>
-    <version>17.0.6</version>
+    <version>17.0.8</version>
     <packageSourceUrl>https://github.com/johanjanssen/ChocolateyPackages/tree/master/Microsoft-OpenJDK17</packageSourceUrl>
     <title>Microsoft build of OpenJDK 17</title>
     <authors>Microsoft</authors>

--- a/Microsoft-OpenJDK17/tools/chocolateyinstall.ps1
+++ b/Microsoft-OpenJDK17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://aka.ms/download-jdk/microsoft-jdk-17.0.6-windows-x64.msi'
-  Checksum64 = 'ad3c2ea8b991bcb99eedff9d09962ae8d2fe8215955b5ce3f268c42cd492bcc8'
+  Url64bit = 'https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.msi'
+  Checksum64 = 'f029e88cdadce4e32bf8e45c2ae31d6015996f10bd836eb255bae86d8246d332'
   ChecksumType64 = 'sha256'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"


### PR DESCRIPTION
Updated the following applications:
- microsoft-openjdk `v17.0.6` → `v17.0.8`
- microsoft-openjdk11 `v11.0.18` → `v11.0.20`
- microsoft-openjdk17 `v17.0.6` → `v17.0.8`

Please verify and merge this Pull Request as soon as possible.

Thank you for maintaining these packages.

