### PR TITLE
Fix ID of Corretto 17 JDK

### DIFF
--- a/Corretto17JDK/corretto17jdk.nuspec
+++ b/Corretto17JDK/corretto17jdk.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>corretto21jdk</id>
+    <id>corretto17jdk</id>
     <version>17.0.9</version>
     <packageSourceUrl>https://github.com/johanjanssen/ChocolateyPackages/tree/master/Corretto17JDK</packageSourceUrl>
     <title>Corretto 17 JDK</title>


### PR DESCRIPTION
Fix an erroneous update of the Corretto 17 SDK ID to the ID of the Corretto 21 JDK ID in d64bbe90dcef74d33e9654af9a1a3f0903e84f6e.

The incorrect ID causes the latest Corretto 17 SDK release not to be available in Chocolaty.

See https://community.chocolatey.org/packages/corretto17jdk